### PR TITLE
Update usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,10 @@ app.module
 
 ```javascript
 /*...*/
-import { GSTCComponent } from "angular-gantt-schedule-timeline-calendar";
+import { AngularGanttScheduleTimelineCalendarModule } from "angular-gantt-schedule-timeline-calendar";
 
 @NgModule({
-  declarations: [/*...*/ GSTCComponent, /*...*/],
+  imports: [/*...*/ AngularGanttScheduleTimelineCalendarModule, /*...*/],
   /*...*/
 })
 /*...*/


### PR DESCRIPTION
As mentioned in #16, I'm currently unable to use the project with the current usage instructions in the readme. After some trying I figured out that I had to import the `AngularGanttScheduleTimelineCalendarModule` module instead to get it to work.

I updated the readme to reflect this.

Feel free to reject if this is the wrong way of doing it, if it is, could you provide a different (working) solution? (I'm using angular 9) 